### PR TITLE
compativel com django 1.9 e retrocompatível

### DIFF
--- a/localbr/formfields.py
+++ b/localbr/formfields.py
@@ -3,8 +3,17 @@
 from datetime import date
 
 from django.forms import FloatField, DecimalField, MultiValueField, ValidationError
-from django.utils.encoding import smart_unicode
-from widgets import BRDecimalWidget, PointWidget, BRFloatWidget, BRJsDateWidget
+
+try:
+    from django.utils.encoding import smart_char as smart_char
+except:
+    from django.utils.encoding import smart_str  as smart_char
+
+try:
+    from widgets import BRDecimalWidget, PointWidget, BRFloatWidget
+except:
+    from localbr.widgets import BRDecimalWidget, PointWidget, BRFloatWidget
+
 from django.forms.fields import EMPTY_VALUES
 from django.utils.safestring import mark_safe
 from django.forms.fields import Field
@@ -42,7 +51,7 @@ class BRPhoneNumberField(Field):
         super(BRPhoneNumberField, self).clean(value)
         if value in EMPTY_VALUES:
             return u''
-        value = re.sub('(\(|\)|\s+)', '', smart_unicode(value))
+        value = re.sub('(\(|\)|\s+)', '', smart_char(value))
         m = re.compile(
             r'^(\d{2})[-\.]?((\d{5})|(\d{4}))[-\.]?(\d{4})$').search(value)
         if m:

--- a/localbr/formfields.py
+++ b/localbr/formfields.py
@@ -10,9 +10,10 @@ except:
     from django.utils.encoding import smart_str  as smart_char
 
 try:
-    from widgets import BRDecimalWidget, PointWidget, BRFloatWidget
+    from widgets import BRDecimalWidget, PointWidget, BRFloatWidget, BRJsDateWidget
 except:
-    from localbr.widgets import BRDecimalWidget, PointWidget, BRFloatWidget
+    from localbr.widgets import BRDecimalWidget, PointWidget, BRFloatWidget, BRJsDateWidget
+
 
 from django.forms.fields import EMPTY_VALUES
 from django.utils.safestring import mark_safe
@@ -64,7 +65,10 @@ class BRDecimalField(DecimalField):
     widget = BRDecimalWidget
 
     def clean(self, value):
-        value = unicode(value).replace('.', '').replace(',', '.')
+        try:
+            value = unicode(value).replace('.', '').replace(',', '.')
+        except:  # python 3
+            value = str(value).replace('.', '').replace(',', '.')
         return super(BRDecimalField, self).clean(value)
 
 
@@ -72,7 +76,10 @@ class BRFloatField(FloatField):
     widget = BRFloatWidget
 
     def clean(self, value):
-        value = unicode(value).replace('.', '').replace(',', '.')
+        try:
+            value = unicode(value).replace('.', '').replace(',', '.')
+        except:  # python 3
+            value = str(value).replace('.', '').replace(',', '.')
         return super(BRFloatField, self).clean(value)
 
 

--- a/localbr/formfields.py
+++ b/localbr/formfields.py
@@ -5,7 +5,7 @@ from datetime import date
 from django.forms import FloatField, DecimalField, MultiValueField, ValidationError
 
 try:
-    from django.utils.encoding import smart_char as smart_char
+    from django.utils.encoding import smart_unicode as smart_char
 except:
     from django.utils.encoding import smart_str  as smart_char
 


### PR DESCRIPTION
django 1.9 não tem smart_unicode:

"from django.utils.encoding import smart_unicode"

no django 1.9, para importar do widget, precisa passar mais um 'caminho'