### PR TITLE
Removido o modulo six

### DIFF
--- a/localbr/utils.py
+++ b/localbr/utils.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from decimal import Decimal
 
 from django.conf import settings
-from django.utils import six
 from django.utils.safestring import mark_safe
 
 
@@ -27,13 +26,13 @@ def numberformat(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep
     use_grouping = use_grouping and grouping > 0
     # Make the common case fast
     if isinstance(number, int) and not use_grouping and not decimal_pos:
-        return mark_safe(six.text_type(number))
+        return mark_safe(str(number))
     # sign
     sign = ''
     if isinstance(number, (Decimal, float)):
         str_number = '{:f}'.format(number)
     else:
-        str_number = six.text_type(number)
+        str_number = str(number)
     if str_number[0] == '-':
         sign = '-'
         str_number = str_number[1:]


### PR DESCRIPTION
Devido que no Django 3 não há mas suporte para o python 2, foi removido a função text_type pela função str do python 3.